### PR TITLE
feat: implement ability to skip transaction during migration

### DIFF
--- a/internal/database/iface.go
+++ b/internal/database/iface.go
@@ -23,14 +23,7 @@ type Scanner interface {
 }
 
 type Tx interface {
-	// For transactions, we only implement the basic DB interface methods,
-	// not the retry versions since retries happen at the DB level
-	Close() error
-	Ping(context.Context) error
-	Exec(context.Context, *sqlf.Query) error
-	QueryRow(context.Context, *sqlf.Query) *sql.Row
-	Query(context.Context, *sqlf.Query) (*sql.Rows, error)
-	WithTransact(ctx context.Context, f func(Tx) error) error
+	DB
 
 	Commit() error
 	Rollback() error

--- a/internal/database/tx.go
+++ b/internal/database/tx.go
@@ -32,7 +32,6 @@ func (d *databaseTx) Exec(ctx context.Context, query *sqlf.Query) error {
 	return err
 }
 
-
 func (d *databaseTx) QueryRow(ctx context.Context, query *sqlf.Query) *sql.Row {
 	return d.tx.QueryRowContext(ctx, query.Query(d.bindVar), query.Args()...)
 }

--- a/internal/migration/template.go
+++ b/internal/migration/template.go
@@ -2,6 +2,7 @@ package migration
 
 const metadataFileTemplate = `name: %s
 timestamp: %d
+skipTransaction: false
 description: |
   <add comment about your migration in here>
 `

--- a/internal/types/migration.go
+++ b/internal/types/migration.go
@@ -10,8 +10,10 @@ type Migration struct {
 
 // MigrationMetadata represents the metadata of a migration file.
 type MigrationMetadata struct {
-	Name      string `yaml:"name"`
-	Timestamp int64  `yaml:"timestamp"`
+	Name            string `yaml:"name"`
+	Timestamp       int64  `yaml:"timestamp"`
+	Description     string `yaml:"description"`
+	SkipTransaction bool   `yaml:"skipTransaction"`
 }
 
 // MigrationOperationType represents the type of migration operation.


### PR DESCRIPTION
This adds the functionality of being able to run your migrations in a transaction and opt out of that if the migration script wants to control the transaction isntead.