### PR TITLE
refactor migration metadata

### DIFF
--- a/cmd/kat/command.go
+++ b/cmd/kat/command.go
@@ -16,7 +16,7 @@ import (
 	"github.com/BolajiOlajide/kat/internal/version"
 )
 
-func add(c *cli.Context) error {
+func addExec(c *cli.Context) error {
 	args := c.Args().Slice()
 	if len(args) == 0 {
 		return cli.Exit("no migration name specified", 1)
@@ -25,11 +25,7 @@ func add(c *cli.Context) error {
 		return cli.Exit("too many arguments", 1)
 	}
 
-	cfg, err := config.GetKatConfigFromCtx(c)
-	if err != nil {
-		return err
-	}
-	return migration.Add(args[0], cfg)
+	return migration.Add(c, args[0])
 }
 
 func up(c *cli.Context) error {

--- a/cmd/kat/main.go
+++ b/cmd/kat/main.go
@@ -25,6 +25,12 @@ func main() {
 
 var verbose bool
 
+var descriptionFlag = &cli.StringFlag{
+	Name:    "description",
+	Usage:   "-d <description of the migration>",
+	Aliases: []string{"d"},
+}
+
 var configFlag = &cli.PathFlag{
 	Name:    "config",
 	Usage:   "the configuration file for kat",
@@ -163,9 +169,9 @@ var kat = &cli.App{
 			ArgsUsage:   "<n>",
 			Usage:       "Create migration",
 			Description: "Creates a new migration file in the migrations directory",
-			Action:      add,
+			Action:      addExec,
 			Before:      config.ParseConfig,
-			Flags:       []cli.Flag{configFlag},
+			Flags:       []cli.Flag{configFlag, descriptionFlag},
 		},
 		{
 			Name:        "up",

--- a/internal/migration/add.go
+++ b/internal/migration/add.go
@@ -6,28 +6,41 @@ import (
 	"strings"
 	"time"
 
+	"github.com/BolajiOlajide/kat/internal/config"
 	"github.com/BolajiOlajide/kat/internal/output"
 	"github.com/BolajiOlajide/kat/internal/types"
+	"github.com/urfave/cli/v2"
 )
 
 // Add creates a new directory with stub migration files in the given schema and returns the
 // names of the newly created files. If there was an error, the filesystem is rolled-back.
-func Add(name string, cfg types.Config) error {
+func Add(c *cli.Context, name string) error {
+	cfg, err := config.GetKatConfigFromCtx(c)
+	if err != nil {
+		return err
+	}
+
 	timestamp := time.Now().UTC().Unix()
 	sanitizedName := nonAlphaNumericOrUnderscore.ReplaceAllString(
 		strings.ReplaceAll(strings.ToLower(name), " ", "_"), "",
 	)
-	migrationName := fmt.Sprintf("%d_%s", timestamp, sanitizedName)
+	migrationDirName := fmt.Sprintf("%d_%s", timestamp, sanitizedName)
 
 	m := types.Migration{
-		Up:        filepath.Join(cfg.Migration.Directory, fmt.Sprintf("%s/up.sql", migrationName)),
-		Down:      filepath.Join(cfg.Migration.Directory, fmt.Sprintf("%s/down.sql", migrationName)),
-		Metadata:  filepath.Join(cfg.Migration.Directory, fmt.Sprintf("%s/metadata.yaml", migrationName)),
+		Up:        filepath.Join(cfg.Migration.Directory, migrationDirName, "up.sql"),
+		Down:      filepath.Join(cfg.Migration.Directory, migrationDirName, "down.sql"),
+		Metadata:  filepath.Join(cfg.Migration.Directory, migrationDirName, "metadata.yaml"),
 		Timestamp: timestamp,
 	}
 
-	err := saveMigration(m, migrationName)
-	if err != nil {
+	md := types.MigrationMetadata{
+		Name:        sanitizedName,
+		Timestamp:   timestamp,
+		Description: c.String("description"),
+		Parents:     nil,
+	}
+
+	if err := saveMigration(m, md); err != nil {
 		return err
 	}
 

--- a/internal/migration/migration.go
+++ b/internal/migration/migration.go
@@ -1,18 +1,19 @@
 package migration
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
 
 	"github.com/BolajiOlajide/kat/internal/types"
+	"github.com/cockroachdb/errors"
+	"gopkg.in/yaml.v3"
 )
 
 // FilePerm is the standard permission for migration files (readable by all, writable by owner)
 const FilePerm = 0644
 
-func saveMigration(m types.Migration, name string) (err error) {
+func saveMigration(m types.Migration, metadata types.MigrationMetadata) (err error) {
 	defer func() {
 		if err != nil {
 			// undo any changes to the fs on error. we don't care about the errors here.
@@ -22,29 +23,31 @@ func saveMigration(m types.Migration, name string) (err error) {
 		}
 	}()
 
-	// write the up.sql file
-	if err := os.MkdirAll(filepath.Dir(m.Up), os.ModePerm); err != nil {
-		return err
-	}
-	if err := os.WriteFile(m.Up, []byte(upMigrationFileTemplate), os.FileMode(FilePerm)); err != nil {
-		return err
+	// Create directory once for all files
+	dir := filepath.Dir(m.Up)
+	if err := os.MkdirAll(dir, os.ModePerm); err != nil {
+		return errors.Wrap(err, "failed to create migration directory")
 	}
 
-	// write the down.sql file
-	if err := os.MkdirAll(filepath.Dir(m.Down), os.ModePerm); err != nil {
-		return err
-	}
-	if err := os.WriteFile(m.Down, []byte(downMigrationFileTemplate), os.FileMode(FilePerm)); err != nil {
-		return err
+	// Prepare all file contents
+	upContent := []byte(upMigrationFileTemplate)
+	downContent := []byte(downMigrationFileTemplate)
+	metadataContent, err := yaml.Marshal(&metadata)
+	if err != nil {
+		return errors.Wrap(err, "failed to marshal metadata")
 	}
 
-	// write the metadata.yaml file
-	if err := os.MkdirAll(filepath.Dir(m.Metadata), os.ModePerm); err != nil {
-		return err
+	// Write all files
+	files := map[string][]byte{
+		m.Up:       upContent,
+		m.Down:     downContent,
+		m.Metadata: metadataContent,
 	}
-	metadata := fmt.Sprintf(metadataFileTemplate, name, m.Timestamp)
-	if err := os.WriteFile(m.Metadata, []byte(metadata), os.FileMode(FilePerm)); err != nil {
-		return err
+
+	for path, content := range files {
+		if err := os.WriteFile(path, content, os.FileMode(FilePerm)); err != nil {
+			return errors.Wrapf(err, "failed to write %s", filepath.Base(path))
+		}
 	}
 
 	return nil

--- a/internal/migration/template.go
+++ b/internal/migration/template.go
@@ -1,11 +1,5 @@
 package migration
 
-const metadataFileTemplate = `name: %s
-timestamp: %d
-description: |
-  <add comment about your migration in here>
-`
-
 const downMigrationFileTemplate = `-- Undo the changes made in the up migration
 --
 -- Note: All migrations in kat are automatically wrapped in a transaction.

--- a/internal/types/migration.go
+++ b/internal/types/migration.go
@@ -13,6 +13,9 @@ type MigrationMetadata struct {
 	Name        string  `yaml:"name"`
 	Timestamp   int64   `yaml:"timestamp"`
 	Description string  `yaml:"description,omitempty"`
+	
+	// Parents represents the timestamps of parent migrations in the dependency graph.
+	// This field is used to define dependencies between migrations.
 	Parents     []int64 `yaml:"parents,omitempty,flow"`
 }
 

--- a/internal/types/migration.go
+++ b/internal/types/migration.go
@@ -10,9 +10,10 @@ type Migration struct {
 
 // MigrationMetadata represents the metadata of a migration file.
 type MigrationMetadata struct {
-	Name        string `yaml:"name"`
-	Timestamp   int64  `yaml:"timestamp"`
-	Description string `yaml:"description"`
+	Name        string  `yaml:"name"`
+	Timestamp   int64   `yaml:"timestamp"`
+	Description string  `yaml:"description,omitempty"`
+	Parents     []int64 `yaml:"parents,omitempty,flow"`
 }
 
 // MigrationOperationType represents the type of migration operation.


### PR DESCRIPTION
This changes the way migration metadata is generated and stored.

## Pull Request Overview

This PR refactors how migration metadata is generated and stored. Key changes include adding a new Parents field to migration metadata, switching from a hard-coded metadata template to YAML marshalling, and updating CLI commands to accept a description flag.
- Updated migration metadata structure in internal/types/migration.go
- Refactored file creation logic in internal/migration/migration.go to use YAML marshaling
- Modified CLI commands in cmd/kat to include a description flag and update function names





