### PR TITLE
feat: optimize compute definitions

### DIFF
--- a/internal/migration/add.go
+++ b/internal/migration/add.go
@@ -21,7 +21,7 @@ func Add(c *cli.Context, name string) error {
 		return err
 	}
 
-	f, err := getMigrationsFS(cfg.Migration.Directory)
+	_, err = getMigrationsFS(cfg.Migration.Directory)
 	if err != nil {
 		return errors.Wrap(err, "getting migrations")
 	}

--- a/internal/migration/add.go
+++ b/internal/migration/add.go
@@ -9,6 +9,7 @@ import (
 	"github.com/BolajiOlajide/kat/internal/config"
 	"github.com/BolajiOlajide/kat/internal/output"
 	"github.com/BolajiOlajide/kat/internal/types"
+	"github.com/cockroachdb/errors"
 	"github.com/urfave/cli/v2"
 )
 
@@ -18,6 +19,11 @@ func Add(c *cli.Context, name string) error {
 	cfg, err := config.GetKatConfigFromCtx(c)
 	if err != nil {
 		return err
+	}
+
+	f, err := getMigrationsFS(cfg.Migration.Directory)
+	if err != nil {
+		return errors.Wrap(err, "getting migrations")
 	}
 
 	timestamp := time.Now().UTC().Unix()


### PR DESCRIPTION
This PR optimizes the compute definitions logic by refactoring the file reading routines and updating slice handling for migration definitions. Key changes include:

* Refactoring file reading logic into a single function (readMigrationFiles) that reads up.sql, down.sql, and metadata.yaml in one call.
* Switching from fixed-length slice indexing to appending to a slice for storing migration definitions.
* Enhancing error wrapping in the migration add functionality.