### PR TITLE
fix: create migration directory if it doesn't exist when running `kat add`

### DIFF
--- a/internal/migration/fs.go
+++ b/internal/migration/fs.go
@@ -8,13 +8,16 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// ErrMigrationsDirNotExist is returned when the migrations directory doesn't exist
+var ErrMigrationsDirNotExist = errors.New("migrations directory does not exist")
+
 //go:embed templates/init.tmpl
 var templatesFS embed.FS
 
 func getMigrationsFS(path string) (fs.FS, error) {
 	_, err := os.Stat(path)
 	if os.IsNotExist(err) {
-		return nil, errors.Newf("Migrations directory '%s' does not exist", path)
+		return nil, errors.Wrapf(ErrMigrationsDirNotExist, "path: %s", path)
 	}
 
 	return os.DirFS(path), nil

--- a/internal/migration/fs_test.go
+++ b/internal/migration/fs_test.go
@@ -1,0 +1,54 @@
+package migration
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetMigrationsFS(t *testing.T) {
+	testCases := []struct {
+		name        string
+		setupDir    bool
+		expectError bool
+		errorType   error
+	}{
+		{
+			name:        "success - existing directory",
+			setupDir:    true,
+			expectError: false,
+		},
+		{
+			name:        "error - non-existent directory",
+			setupDir:    false,
+			expectError: true,
+			errorType:   ErrMigrationsDirNotExist,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testDir := t.TempDir()
+			migrationsPath := filepath.Join(testDir, "migrations")
+
+			if tc.setupDir {
+				require.NoError(t, os.MkdirAll(migrationsPath, 0755), "failed to create migrations dir")
+			}
+
+			result, err := getMigrationsFS(migrationsPath)
+
+			if tc.expectError {
+				require.Error(t, err, "expected an error but got none")
+				require.ErrorIs(t, err, tc.errorType, "error type mismatch")
+				require.Nil(t, result, "expected nil filesystem")
+			} else {
+				require.NoError(t, err, "unexpected error")
+				require.NotNil(t, result, "expected non-nil filesystem")
+				require.Implements(t, (*fs.FS)(nil), result, "result should implement fs.FS")
+			}
+		})
+	}
+}


### PR DESCRIPTION
![CleanShot 2025-05-29 at 17 07 11@2x](https://github.com/user-attachments/assets/b0d7b293-633d-48af-8698-1e4e1a4fad42)

There's a bug in Kat where if you run the `kat add` command and the migrations directory isn't present, it'll return an error. An example is show above.

The fix is to create the directory if it doesn't exist.